### PR TITLE
chore: consume the bindings toolbox and declare the upstream manifest

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   cd:
     if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-simple-cd.yml@v2
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-simple-cd.yml@v1
     with:
       generator-project: "MeshOptimizerGen/MeshOptimizerGen/MeshOptimizerGen.csproj"  # Path to your generator .csproj
       generator-name: "MeshOptimizer"                # Name of your generator executable

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci:
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-common-ci.yml@v2
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-common-ci.yml@v1
     with:
       generator-project: "MeshOptimizerGen/MeshOptimizerGen/MeshOptimizerGen.csproj"  # Path to your generator .csproj
       generator-name: "MeshOptimizer"                # Name of your generator executable

--- a/binding.yml
+++ b/binding.yml
@@ -1,0 +1,33 @@
+# Binding manifest — see https://github.com/EvergineTeam/Evergine.Bindings
+# Schema: https://github.com/EvergineTeam/Evergine.Bindings/blob/main/binding.schema.json
+toolbox: 1.0.0
+
+package:
+  id: Evergine.Bindings.MeshOptimizer
+  project: MeshOptimizerGen/Evergine.Bindings.MeshOptimizer/Evergine.Bindings.MeshOptimizer.csproj
+  target-framework: net10.0
+  runtime-identifier: linux-x64
+
+upstream:
+  kind: git-tree
+  language: cpp
+  project: https://github.com/zeux/meshoptimizer
+  version-from: git-release
+  sources:
+    - repo: zeux/meshoptimizer
+      ref: master
+      remote-path: src/meshoptimizer.h
+      path: MeshOptimizerGen/MeshOptimizerGen/Headers/meshoptimizer.h
+      format: c-header
+
+generator:
+  project: MeshOptimizerGen/MeshOptimizerGen/MeshOptimizerGen.csproj
+  name: MeshOptimizer
+  output:
+    - MeshOptimizerGen/Evergine.Bindings.MeshOptimizer/Generated
+
+# NOTE — this package ships native binaries under Evergine.Bindings.MeshOptimizer/runtimes.
+# The header and those binaries must come from the same upstream revision. `ref: master`
+# is a moving target, so a header bump is only valid together with a native rebuild;
+# binding-updater must label any such pull request `needs-human-review`. Pinning `ref`
+# to a release tag would remove this hazard and is worth considering.


### PR DESCRIPTION
Fase 2: repunta CI y CD de `evergine-standards@v2` al toolbox `Evergine.Bindings@v1`, y añade `binding.yml`.

## Evidencia de que es un no-op

El toolbox contiene copias **byte-idénticas** de esos reusables; el único cambio al copiarlos fue repuntar sus `uses:` internos a las acciones del propio toolbox. Verificado ya en dos repos comparando el `.nupkg` del pipeline viejo contra el nuevo:

| Repo | Resultado |
|---|---|
| Vulkan.NET | 7 entradas idénticas, mismos tamaños, ensamblado difiere en 147/1.052.672 bytes (0,0140%) |
| OpenXR.NET | 7 entradas idénticas, mismos tamaños, ensamblado difiere en 147/671.232 bytes (0,0219%) |

Esos 147 bytes son siempre los mismos y son metadatos de build: `TimeDateStamp` del PE, MVID, checksum del PDB y el `InformationalVersion 1.0.0+<sha>`. Cero diferencias de código.

Aquí se ejecuta la misma comparación antes de mergear; si sale algo más, el PR no entra.

## Qué NO cambia

`sync-standards.yml` sigue apuntando a `evergine-standards`: distribuir LICENSE, el icono y los scripts de `build/scripts/` no es cosa del toolbox. Los reusables originales tampoco se borran — son la vía de rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)