### PR TITLE
docs: point at the latest release, and only ask for natives that exist

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -79,7 +79,12 @@ jobs:
       revision: ${{ github.run_number }}
       # Every artifact already carries its final repository path, so unpacking
       # them over the tree is the whole mapping.
-      natives-artifact-pattern: "natives-*"
+      #
+      # Asked for only when the natives job actually ran. It is skipped whenever
+      # the release has not moved -- most runs, and every republish of work already
+      # merged -- and asking for artifacts that were never produced fails the
+      # download and takes the publish with it.
+      natives-artifact-pattern: ${{ needs.natives.result == 'success' && 'natives-*' || '' }}
       force-publish: ${{ inputs.force-publish || false }}
       publish-enabled: ${{ !inputs.skip-assets-publishing }}
       enable-email-notifications: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # MeshOptimizer.NET
 
 This repository contains low-level bindings for MeshOptimizer used in Evergine.
-This binding is generated from the MeshOptimizer release:
-[https://github.com/zeux/meshoptimizer/releases/tag/v1.2](https://github.com/zeux/meshoptimizer/releases/tag/v1.2)
+
+This binding tracks the [latest stable MeshOptimizer release](https://github.com/zeux/meshoptimizer/releases/latest),
+header and native libraries together. The exact revision currently vendored is
+recorded in [`binding.yml`](binding.yml) as `upstream.release.current`, which the
+CD rewrites when it brings in a newer release — so there is one place to look and
+nothing here to keep up to date by hand.
 
 [![CI](https://github.com/EvergineTeam/Meshoptimizer.NET/actions/workflows/CI.yml/badge.svg)](https://github.com/EvergineTeam/Meshoptimizer.NET/actions/workflows/CI.yml)
 [![CD](https://github.com/EvergineTeam/Meshoptimizer.NET/actions/workflows/CD.yml/badge.svg)](https://github.com/EvergineTeam/Meshoptimizer.NET/actions/workflows/CD.yml)


### PR DESCRIPTION
The README named a specific tag, so it went stale the moment upstream published
anything and had to be edited on every bump. GitHub's /releases/latest never
does. But a link to "latest" under the words "generated from this release" would
have been a lie between bumps, so the sentence now says what is true: the binding
tracks the latest stable release, and the revision actually vendored lives in
binding.yml, which the CD maintains.

Also stops asking for native artifacts when the job that builds them was skipped.
It is skipped whenever the release has not moved -- most runs, and every republish
of work already merged -- and downloading artifacts that were never produced fails
the step and takes the publish with it.
